### PR TITLE
update prelim.R to speed up

### DIFF
--- a/analysis/prelim.R
+++ b/analysis/prelim.R
@@ -2,7 +2,7 @@
 pacman::p_load(dplyr,tictoc,purrr,lubridate,glue,tidyverse,jsonlite,here,arrow)
 
 #json file containing vax study dates
-study_dates <- fromJSON("output/study_dates.json", format="%Y-%m-%d")
+study_dates <- fromJSON("output/study_dates.json")
 delta_date <- as.Date(study_dates$delta_date, format="%Y-%m-%d")
 delta_end_date <- as.Date(study_dates$omicron_date, format="%Y-%m-%d")
 all_eligible_date <- as.Date(study_dates$all_eligible,format="%Y-%m-%d")


### PR DESCRIPTION
The code previously was very slow to run inside OpenSAFELY. I think this is most likely because "rowwise" and "rep(row))" were used simultaneously. I've updated the code. Using dummy data N = 10,000, the new code runs the action in the yaml in ~35 seconds. The old code was taking >25 minutes, so this change speeds up the action by a magnitude of ~50. 

I ran the old code and the new code and read the CSV's into R and compared them using "all.equal" and the output seems to be identical which is what we want. 

```
all.equal(indexdates, indexdates2)
[1] TRUE
```
@marwaalarab please check you are happy that the code is doing what we want it to. Included @venexia as well for reference. Thanks.